### PR TITLE
Improve comments

### DIFF
--- a/codestripper/cli.py
+++ b/codestripper/cli.py
@@ -13,8 +13,8 @@ def add_commandline_arguments(parser: argparse.ArgumentParser) -> None:
     # Add optional arguments
     parser.add_argument("-x", "--exclude", action="append",
                         help="files to include for code stripping (glob)", default=[])
-    parser.add_argument("-c", "--comment", action="store",
-                        help="comment symbol(s) for the given language", default="//")
+    parser.add_argument("-c", "--comment", action="append",
+                        help="comment symbol(s) for the given language, usage: <extension>:<comment> (e.g. .java://")
     parser.add_argument("-v", "--verbosity", action="count", help="increase output verbosity", default=0)
     parser.add_argument("-o", "--output", action="store",
                         help="output directory to store the stripped files", default="out")
@@ -44,4 +44,6 @@ def main() -> None:
     cwd = get_working_directory(args.working_directory)
     files = FileUtils(args.include, args.exclude, cwd, args.recursive, logger_name).get_matching_files()
     # Strip all the files
-    strip_files(files, cwd, args.comment, args.output, args.dry_run, args.fail_on_error)
+
+    strip_files(files, cwd, comments=args.comment, output=args.output, dry_run=args.dry_run,
+                fail_on_error=args.fail_on_error)

--- a/codestripper/code_stripper.py
+++ b/codestripper/code_stripper.py
@@ -9,6 +9,7 @@ from codestripper.tags import IgnoreFileError
 from codestripper.tags.tag import Tag, RangeTag
 from codestripper.tokenizer import Tokenizer
 from codestripper.utils import get_working_directory
+from codestripper.utils.comments import comments_mapping, Comment
 
 logger = logging.getLogger("codestripper")
 
@@ -26,7 +27,14 @@ def strip_files(files: Iterable[str], working_directory: Union[str, None] = None
             content = handle.read()
         if content is not None:
             try:
-                stripped = CodeStripper(content, comment).strip()
+                _, file_extension = os.path.splitext(file)
+                file_extension = file_extension.lower()
+                if not file_extension in comments_mapping:
+                    logger.error(f"Unknown extension: '{file_extension}', "
+                                 f"please specify which comment to use for this file extension.")
+                    continue
+                com = comments_mapping[file_extension]
+                stripped = CodeStripper(content, com).strip()
             except IgnoreFileError:
                 logger.info(f"File '{file}' is ignored, because of ignore tag")
                 continue
@@ -50,7 +58,7 @@ def strip_files(files: Iterable[str], working_directory: Union[str, None] = None
 
 class CodeStripper:
 
-    def __init__(self, content: str, comment: str) -> None:
+    def __init__(self, content: str, comment: Comment) -> None:
         self.content = content
         self.comment = comment
 

--- a/codestripper/code_stripper.py
+++ b/codestripper/code_stripper.py
@@ -2,7 +2,7 @@ import logging
 import os.path
 import shutil
 from pathlib import Path
-from typing import Union, Iterable, List
+from typing import Union, Iterable, List, Optional
 
 from codestripper.errors import InvalidTagError, TokenizerError
 from codestripper.tags import IgnoreFileError
@@ -14,7 +14,7 @@ from codestripper.utils.comments import comments_mapping, Comment
 logger = logging.getLogger("codestripper")
 
 
-def strip_files(files: Iterable[str], working_directory: Union[str, None] = None, * ,comments: List[str] = None,
+def strip_files(files: Iterable[str], working_directory: Union[str, None] = None, * ,comments: Optional[List[str]] = None,
                 output: Union[Path, str] = "out", dry_run: bool = False, fail_on_error: bool = False) -> List[str]:
 
     if comments is not None:

--- a/codestripper/code_stripper.py
+++ b/codestripper/code_stripper.py
@@ -14,8 +14,17 @@ from codestripper.utils.comments import comments_mapping, Comment
 logger = logging.getLogger("codestripper")
 
 
-def strip_files(files: Iterable[str], working_directory: Union[str, None] = None, comment: str = "//",
+def strip_files(files: Iterable[str], working_directory: Union[str, None] = None, * ,comments: List[str] = None,
                 output: Union[Path, str] = "out", dry_run: bool = False, fail_on_error: bool = False) -> List[str]:
+
+    if comments is not None:
+        for comment in comments:
+            parts = comment.split(":")
+            if len(parts) == 2:
+                comments_mapping[parts[0]] = Comment(parts[1])
+            else:
+                comments_mapping[parts[0]] = Comment(parts[1], parts[2])
+
     cwd = get_working_directory(working_directory)
     out = os.path.join(os.getcwd(), output)
     if os.path.isdir(out):

--- a/codestripper/tags/add.py
+++ b/codestripper/tags/add.py
@@ -4,7 +4,7 @@ from codestripper.tags.tag import SingleTag, TagData
 
 
 class AddTag(SingleTag):
-    regex = r'cs:add:(.*?)'
+    regex = r'cs:add:(.*)?'
 
     def __init__(self, data: TagData) -> None:
         super().__init__(data)

--- a/codestripper/tags/add.py
+++ b/codestripper/tags/add.py
@@ -4,7 +4,7 @@ from codestripper.tags.tag import SingleTag, TagData
 
 
 class AddTag(SingleTag):
-    regex = r'cs:add:(.*?)$'
+    regex = r'cs:add:(.*?)'
 
     def __init__(self, data: TagData) -> None:
         super().__init__(data)

--- a/codestripper/tags/legacy.py
+++ b/codestripper/tags/legacy.py
@@ -4,7 +4,7 @@ from codestripper.tags.tag import RangeTag, RangeOpenTag, RangeCloseTag, TagData
 
 
 class LegacyOpenTag(RangeOpenTag):
-    regex = r'Start Solution::replacewith::(.*?)$'
+    regex = r'Start Solution::replacewith::(.*)'
 
     def __init__(self, data: TagData) -> None:
         super().__init__(LegacyRangeTag, data)
@@ -20,7 +20,7 @@ class LegacyOpenTag(RangeOpenTag):
 
 
 class LegacyCloseTag(RangeCloseTag):
-    regex = r'End Solution::replacewith::(.*?)$'
+    regex = r'End Solution::replacewith::(.*)'
 
     def __init__(self, data: TagData) -> None:
         super().__init__(LegacyRangeTag, data)

--- a/codestripper/tags/remove.py
+++ b/codestripper/tags/remove.py
@@ -3,7 +3,7 @@ from codestripper.tags.tag import RangeTag, RangeOpenTag, RangeCloseTag, TagData
 
 class RemoveTag(SingleTag):
 
-    regex = r'cs:remove\s*?$'
+    regex = r'cs:remove(?!:)(.*)?'
 
     def __init__(self, data: TagData):
         super().__init__(data)

--- a/codestripper/tags/replace.py
+++ b/codestripper/tags/replace.py
@@ -2,7 +2,7 @@ from codestripper.tags.tag import SingleTag, TagData
 
 
 class ReplaceTag(SingleTag):
-    regex = r'cs:replace:(.*?)$'
+    regex = r'cs:replace:(.*?)'
 
     def __init__(self, data: TagData) -> None:
         super().__init__(data)

--- a/codestripper/tags/tag.py
+++ b/codestripper/tags/tag.py
@@ -2,6 +2,8 @@ import re
 from dataclasses import dataclass
 from typing import Type, Union, List, Pattern, Iterable, Optional
 
+from codestripper.utils.comments import Comment
+
 
 @dataclass
 class TagData:
@@ -13,7 +15,7 @@ class TagData:
     regex_end: int
     parameter_start: int
     parameter_end: int
-    comment: str
+    comment: Comment
 
     def __repr__(self) -> str:
         return (f"{self.line}, line ({self.line_number}): {self.line_start}:{self.line_end},"

--- a/codestripper/tags/uncomment.py
+++ b/codestripper/tags/uncomment.py
@@ -5,14 +5,14 @@ from codestripper.tags.tag import RangeTag, RangeOpenTag, RangeCloseTag, TagData
 
 
 class UncommentOpenTag(RangeOpenTag):
-    regex = r'cs:uncomment:start.*?'
+    regex = r'cs:uncomment:start(.*)?'
 
     def __init__(self, data: TagData) -> None:
         super().__init__(UncommentRangeTag, data)
 
 
 class UncommentCloseTag(RangeCloseTag):
-    regex = 'cs:uncomment:end.*?'
+    regex = 'cs:uncomment:end(.*)?'
 
     def __init__(self, data: TagData) -> None:
         super().__init__(UncommentRangeTag, data)
@@ -27,7 +27,7 @@ class UncommentRangeTag(RangeTag):
     def execute(self, content: str) -> Union[str, None]:
         if UncommentRangeTag.regex is None:
             whitespace = r"(?P<whitespace>\s*)"
-            UncommentRangeTag.regex = re.compile(f"{whitespace}{self.open_tag.data.comment}")
+            UncommentRangeTag.regex = re.compile(f"{whitespace}{self.open_tag.data.comment.open}")
         range = content[self.start:self.end]
         replacement = UncommentRangeTag.regex.sub(r"\g<whitespace>", range)
         return replacement

--- a/codestripper/tags/uncomment.py
+++ b/codestripper/tags/uncomment.py
@@ -5,14 +5,14 @@ from codestripper.tags.tag import RangeTag, RangeOpenTag, RangeCloseTag, TagData
 
 
 class UncommentOpenTag(RangeOpenTag):
-    regex = r'cs:uncomment:start.*?$'
+    regex = r'cs:uncomment:start.*?'
 
     def __init__(self, data: TagData) -> None:
         super().__init__(UncommentRangeTag, data)
 
 
 class UncommentCloseTag(RangeCloseTag):
-    regex = 'cs:uncomment:end.*?$'
+    regex = 'cs:uncomment:end.*?'
 
     def __init__(self, data: TagData) -> None:
         super().__init__(UncommentRangeTag, data)

--- a/codestripper/tokenizer.py
+++ b/codestripper/tokenizer.py
@@ -32,7 +32,10 @@ def calculate_mappings(tags: Set[Type[SingleTag]], comment: Comment) -> Tuple[Cr
     for tag in tags:
         name = f"{tag.__name__}"
         mappings[name] = lambda data, constructor=tag: constructor(data)
-        strings.append(f"(?P<{name}>{re.escape(comment.open)}{tag.regex})")
+        reg = f"(?P<{name}>{re.escape(comment.open)}{tag.regex})"
+        if comment.close is not None:
+            reg += re.escape(comment.close)
+        strings.append(reg)
     regex = re.compile("|".join(strings), flags=re.MULTILINE)
     return mappings, regex  # type: ignore
 

--- a/codestripper/tokenizer.py
+++ b/codestripper/tokenizer.py
@@ -38,6 +38,7 @@ def calculate_mappings(tags: Set[Type[SingleTag]], comment: Comment) -> Tuple[Cr
 
 
 class Tokenizer:
+    mapping_cache: Dict[str, Tuple[CreateTagMapping, Pattern]] = {}
     mappings: CreateTagMapping = {}
     regex: Pattern = re.compile("")
     comment: Comment
@@ -47,9 +48,11 @@ class Tokenizer:
         self.ordered_tags: List[Tag] = []
         self.open_stack: List[RangeOpenTag] = []
         self.range_stack: Dict[int, Optional[List[Tag]]] = {}
-        if len(Tokenizer.mappings) == 0 or Tokenizer.comment != comment:
-            Tokenizer.mappings, Tokenizer.regex = calculate_mappings(default_tags, comment)
-            Tokenizer.comment = comment
+        Tokenizer.comment = comment
+        if not str(comment) in Tokenizer.mapping_cache:
+            Tokenizer.mapping_cache[str(comment)] = calculate_mappings(default_tags, comment)
+        Tokenizer.mappings = Tokenizer.mapping_cache[str(comment)][0]
+        Tokenizer.regex = Tokenizer.mapping_cache[str(comment)][1]
         self.group_count = self.regex.groups
 
     def tokenize(self) -> List[Tag]:

--- a/codestripper/tokenizer.py
+++ b/codestripper/tokenizer.py
@@ -32,7 +32,7 @@ def calculate_mappings(tags: Set[Type[SingleTag]], comment: Comment) -> Tuple[Cr
     for tag in tags:
         name = f"{tag.__name__}"
         mappings[name] = lambda data, constructor=tag: constructor(data)
-        strings.append(f"(?P<{name}>{comment.open}{tag.regex})")
+        strings.append(f"(?P<{name}>{re.escape(comment.open)}{tag.regex})")
     regex = re.compile("|".join(strings), flags=re.MULTILINE)
     return mappings, regex  # type: ignore
 

--- a/codestripper/utils/comments.py
+++ b/codestripper/utils/comments.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Optional, Dict
+
+
+@dataclass
+class Comment:
+    open: str
+    close: Optional[str] = None
+
+comments_mapping: Dict[str, Comment] = {
+    ".java": Comment("//"),
+    ".cs": Comment("//"),
+    ".js": Comment("//"),
+    ".php": Comment("//"),
+    ".swift": Comment("//"),
+    ".xml": Comment("<!--", "-->"),
+    ".tex": Comment("%"),
+    ".m": Comment("%"),
+    ".sql": Comment("--"),
+    ".lua": Comment("--"),
+    ".ml": Comment("(*", "*)"),
+    ".r": Comment("#"),
+    ".py": Comment("#"),
+    ".ps1": Comment("#"),
+    ".rb": Comment("#")
+}

--- a/codestripper/utils/comments.py
+++ b/codestripper/utils/comments.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Optional, Dict
 
 
-@dataclass
+@dataclass(frozen=True)
 class Comment:
     open: str
     close: Optional[str] = None

--- a/codestripper/utils/file.py
+++ b/codestripper/utils/file.py
@@ -52,7 +52,7 @@ class FileUtils:
         return files
 
     def get_matching_files(self) -> Iterable[str]:
-        """Get files that fullfill requirements, match included and do not match excluded"""
+        """Get files that fulfill requirements, match included and do not match excluded"""
         os.chdir(self.cwd)
         included_files = self.__convert_to_paths_set(self.included, self.recursive)
         self.logger.debug(f"Included files are: {included_files}")

--- a/tests/tags/test_add.py
+++ b/tests/tags/test_add.py
@@ -1,4 +1,5 @@
 from codestripper.code_stripper import CodeStripper
+from codestripper.utils.comments import Comment
 
 
 def test_add_should_add():
@@ -12,26 +13,26 @@ def test_add_should_add():
         //TODO
 
     """
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Add should add the replacement"
 
 
 def test_add_valid():
     case = "//cs:add"
     expected = "//cs:add"
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Add should only trigger with valid tag"
 
 
 def test_add_without_replacement():
     case = "    //cs:add:"
     expected = "    "
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Add without replacement keeps whitelines"
 
 
 def test_add_with_content_before():
     case = """asd//cs:add:test"""
     expected = """asdtest"""
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Replace should replace with empty string keeping whitespace"

--- a/tests/tags/test_add.py
+++ b/tests/tags/test_add.py
@@ -17,6 +17,20 @@ def test_add_should_add():
     assert output == expected, "Add should add the replacement"
 
 
+def test_add_should_add_closing():
+    case = """
+    public class AssessmentResult {
+        <!--cs:add://TODO-->
+
+    """
+    expected = """
+    public class AssessmentResult {
+        //TODO
+
+    """
+    output = CodeStripper(case, Comment("<!--", "-->")).strip()
+    assert output == expected, "Add should add the replacement"
+
 def test_add_valid():
     case = "//cs:add"
     expected = "//cs:add"

--- a/tests/tags/test_ignore_file.py
+++ b/tests/tags/test_ignore_file.py
@@ -21,3 +21,8 @@ def test_ignored_file():
     case = "//cs:ignore"
     with pytest.raises(IgnoreFileError):
         CodeStripper(case, Comment("//")).strip()
+
+def test_ignored_file_closing():
+    case = "<!--cs:ignore-->"
+    with pytest.raises(IgnoreFileError):
+        CodeStripper(case, Comment("<!--", "-->")).strip()

--- a/tests/tags/test_ignore_file.py
+++ b/tests/tags/test_ignore_file.py
@@ -3,6 +3,7 @@ import pytest
 from codestripper.code_stripper import CodeStripper
 from codestripper.errors import InvalidTagError
 from codestripper.tags import IgnoreFileError
+from codestripper.utils.comments import Comment
 
 
 def test_invalid_tag():
@@ -11,7 +12,7 @@ def test_invalid_tag():
     //cs:ignore
     """
     with pytest.raises(InvalidTagError) as ex:
-        CodeStripper(case, "//").strip()
+        CodeStripper(case, Comment("//")).strip()
     message = str(ex)
     assert message.__contains__("IgnoreFileTag")
 
@@ -19,4 +20,4 @@ def test_invalid_tag():
 def test_ignored_file():
     case = "//cs:ignore"
     with pytest.raises(IgnoreFileError):
-        CodeStripper(case, "//").strip()
+        CodeStripper(case, Comment("//")).strip()

--- a/tests/tags/test_legacy.py
+++ b/tests/tags/test_legacy.py
@@ -1,4 +1,5 @@
 from codestripper.code_stripper import CodeStripper
+from codestripper.utils.comments import Comment
 
 
 def test_legacy_should_remove():
@@ -9,7 +10,7 @@ def test_legacy_should_remove():
     """
     expected = """
     """
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Legacy should remove contents inbetween tags"
 
 
@@ -23,5 +24,5 @@ def test_legacy_should_replace():
     start
     end
     """
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Legacy should replace on start and end"

--- a/tests/tags/test_remove.py
+++ b/tests/tags/test_remove.py
@@ -1,4 +1,5 @@
 from codestripper.code_stripper import CodeStripper
+from codestripper.utils.comments import Comment
 
 
 def test_remove_range():
@@ -9,7 +10,7 @@ def test_remove_range():
     """
     expected = """
     """
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Remove should remove all"
 
 
@@ -19,5 +20,5 @@ def test_remove_single():
     """
     expected = """
     """
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Remove should remove single line"

--- a/tests/tags/test_replace.py
+++ b/tests/tags/test_replace.py
@@ -1,4 +1,5 @@
 from codestripper.code_stripper import CodeStripper
+from codestripper.utils.comments import Comment
 
 
 def test_replace():
@@ -8,7 +9,7 @@ def test_replace():
     expected = """
     test
     """
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Replace should replace keeping whitespace"
 
 
@@ -19,7 +20,7 @@ def test_replace_empty():
     expected = """
     
     """
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Replace should replace with empty string keeping whitespace"
 
 
@@ -30,7 +31,7 @@ def test_replace_valid():
     expected = """
     asd//cs:replace
     """
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Only valid replace tag should work"
 
 
@@ -41,5 +42,5 @@ def test_replace_symbol():
     expected = """
     //TODO: test
     """
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Replace with ':' should work"

--- a/tests/tags/test_tags.py
+++ b/tests/tags/test_tags.py
@@ -8,14 +8,14 @@ from codestripper.utils.comments import Comment
 
 
 class InvalidOpenTag(RangeOpenTag):
-    regex = r'cs:invalid:start.*?'
+    regex = r'cs:invalid:start(.*)?'
 
     def __init__(self, data: TagData) -> None:
         super().__init__(InvalidRangeTag, data)
 
 
 class InvalidCloseTag(RangeCloseTag):
-    regex = r'cs:invalid:end.*?'
+    regex = r'cs:invalid:end(.*)?'
 
     def __init__(self, data: TagData) -> None:
         super().__init__(InvalidRangeTag, data)
@@ -109,8 +109,8 @@ def test_mismatch_open_close():
 def test_invalid_tag():
     case = """
             test line
-            !!cs:invalid:start
-            !!cs:invalid:end
+            ^^cs:invalid:start
+            ^^cs:invalid:end
             """
     default_tags = tokenizer.default_tags
     tokenizer.default_tags = {
@@ -118,7 +118,7 @@ def test_invalid_tag():
         InvalidCloseTag
     }
     with pytest.raises(InvalidTagError) as ex:
-        CodeStripper(case, Comment("!!")).strip()
+        CodeStripper(case, Comment("^^")).strip()
     tokenizer.default_tags = default_tags
     assert "InvalidRangeTag" in str(ex)
 

--- a/tests/tags/test_tags.py
+++ b/tests/tags/test_tags.py
@@ -4,6 +4,7 @@ from codestripper import tokenizer
 from codestripper.code_stripper import CodeStripper
 from codestripper.errors import InvalidTagError, TokenizerError
 from codestripper.tags.tag import RangeOpenTag, TagData, RangeCloseTag, RangeTag
+from codestripper.utils.comments import Comment
 
 
 class InvalidOpenTag(RangeOpenTag):
@@ -32,7 +33,7 @@ class InvalidRangeTag(RangeTag):
 def test_comment():
     case = "#cs:add:test"
     expected = "test"
-    output = CodeStripper(case, "#").strip()
+    output = CodeStripper(case, Comment("#")).strip()
     assert output == expected, "Different comments can be used"
 
 
@@ -43,7 +44,7 @@ def test_nested_tags():
     //test2
     //cs:uncomment:end
     """
-    stripper = CodeStripper(case, "//")
+    stripper = CodeStripper(case, Comment("//"))
     output = stripper.strip()
 
     expected = """
@@ -58,7 +59,7 @@ def test_tag_end_file():
     //cs:uncomment:start
     //test2
     //cs:uncomment:end"""
-    stripper = CodeStripper(case, "//")
+    stripper = CodeStripper(case, Comment("//"))
     output = stripper.strip()
 
     expected = """
@@ -72,7 +73,7 @@ def test_missing_close_tag():
         //cs:remove:start
         """
     with pytest.raises(TokenizerError):
-        CodeStripper(case, "//").strip()
+        CodeStripper(case, Comment("//")).strip()
 
 
 def test_missing_close_tag_nested():
@@ -83,7 +84,7 @@ def test_missing_close_tag_nested():
         //cs:remove:end
         """
     with pytest.raises(TokenizerError):
-        CodeStripper(case, "//").strip()
+        CodeStripper(case, Comment("//")).strip()
 
 
 def test_close_without_open():
@@ -92,7 +93,7 @@ def test_close_without_open():
         //cs:remove:end
         """
     with pytest.raises(TokenizerError):
-        CodeStripper(case, "//").strip()
+        CodeStripper(case, Comment("//")).strip()
 
 
 def test_mismatch_open_close():
@@ -102,7 +103,7 @@ def test_mismatch_open_close():
         //cs:remove:end
         """
     with pytest.raises(TokenizerError):
-        CodeStripper(case, "//").strip()
+        CodeStripper(case, Comment("//")).strip()
 
 
 def test_invalid_tag():
@@ -117,7 +118,7 @@ def test_invalid_tag():
         InvalidCloseTag
     }
     with pytest.raises(InvalidTagError) as ex:
-        CodeStripper(case, "!!").strip()
+        CodeStripper(case, Comment("!!")).strip()
     tokenizer.default_tags = default_tags
     assert "InvalidRangeTag" in str(ex)
 

--- a/tests/tags/test_uncomment.py
+++ b/tests/tags/test_uncomment.py
@@ -1,4 +1,5 @@
 from codestripper.code_stripper import CodeStripper
+from codestripper.utils.comments import Comment
 
 
 def test_uncomment_range():
@@ -12,7 +13,7 @@ def test_uncomment_range():
     test
      test2
     """
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Uncomment should uncomment all, keeping whitespace"
 
 
@@ -27,5 +28,5 @@ def test_uncomment_without_comments():
     test
      test2
     """
-    output = CodeStripper(case, "//").strip()
+    output = CodeStripper(case, Comment("//")).strip()
     assert output == expected, "Uncomment shouldn't process non-commented lines"

--- a/tests/test_codestripper.py
+++ b/tests/test_codestripper.py
@@ -40,11 +40,26 @@ def test_project_out(monkeypatch: pytest.MonkeyPatch):
                 break
     assert stripped
 
+
+def test_strip_pom(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(test_project_dir)
+    files = FileUtils(["pom.xml"], working_directory="testproject").get_matching_files()
+    stripped_files = strip_files(files, "testproject", output="out")
+    stripped = len(stripped_files) == 1
+    regex = re.compile("<!--cs:")
+    for file in stripped_files:
+        with open(os.path.join(os.getcwd(), "out", file), 'r') as handle:
+            content = handle.read()
+            if regex.search(content) is not None:
+                stripped = False
+                break
+    assert stripped
+
+
 def test_project_with_custom_comment(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.chdir(test_project_dir)
     files = FileUtils(["**/*.java", "pom.xml", "**/*.test"], working_directory="testproject").get_matching_files()
     stripped_files = strip_files(files, "testproject", comments=[".test:!!"], output="out")
-    stripped = len(stripped_files) == 6
     content: str = ""
     for file in stripped_files:
         if file == "test.test":

--- a/tests/test_codestripper.py
+++ b/tests/test_codestripper.py
@@ -29,7 +29,7 @@ def test_project(monkeypatch: pytest.MonkeyPatch, caplog: LogCaptureFixture):
 def test_project_out(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.chdir(test_project_dir)
     files = FileUtils(["**/*.java", "pom.xml"], working_directory="testproject").get_matching_files()
-    stripped_files = strip_files(files, "testproject", "//", "out", False)
+    stripped_files = strip_files(files, "testproject", output="out")
     stripped = len(stripped_files) == 5
     regex = re.compile("//cs:")
     for file in stripped_files:
@@ -40,12 +40,24 @@ def test_project_out(monkeypatch: pytest.MonkeyPatch):
                 break
     assert stripped
 
+def test_project_with_custom_comment(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(test_project_dir)
+    files = FileUtils(["**/*.java", "pom.xml", "**/*.test"], working_directory="testproject").get_matching_files()
+    stripped_files = strip_files(files, "testproject", comments=[".test:!!"], output="out")
+    stripped = len(stripped_files) == 6
+    content: str = ""
+    for file in stripped_files:
+        if file == "test.test":
+            with open(os.path.join(os.getcwd(), "out", file), 'r') as handle:
+                content = handle.read()
+    assert content == "Custom file extension <-> comment works!"
+
 
 def test_log_missing_close_tag(monkeypatch: pytest.MonkeyPatch, caplog: LogCaptureFixture):
     monkeypatch.chdir(test_project_dir)
     files = FileUtils(["MissingClose.java"], working_directory="files").get_matching_files()
     with caplog.at_level(logging.ERROR, logger='codestripper'):
-        strip_files(files, "files", "//", "out", True)
+        strip_files(files, "files", output="out")
         errors = [rec.message for rec in caplog.records]
         assert len(errors) == 1 and "MissingClose.java" in errors[0] and "1" in errors[0]
 
@@ -54,7 +66,7 @@ def test_log_wrong_close_tag(monkeypatch: pytest.MonkeyPatch, caplog: LogCapture
     monkeypatch.chdir(test_project_dir)
     files = FileUtils(["WrongClose.java"], working_directory="files").get_matching_files()
     with caplog.at_level(logging.ERROR, logger='codestripper'):
-        strip_files(files, "files", "//", "out", True)
+        strip_files(files, "files", output="out")
         errors = [rec.message for rec in caplog.records]
         assert len(errors) == 1 and "WrongClose.java" in errors[0] and "3" in errors[0]
 
@@ -63,7 +75,7 @@ def test_log_missing_open_tag(monkeypatch: pytest.MonkeyPatch, caplog: LogCaptur
     monkeypatch.chdir(test_project_dir)
     files = FileUtils(["MissingOpen.java"], working_directory="files").get_matching_files()
     with caplog.at_level(logging.ERROR, logger='codestripper'):
-        strip_files(files, "files", "//", "out", True)
+        strip_files(files, "files")
         errors = [rec.message for rec in caplog.records]
         assert len(errors) == 1 and "MissingOpen.java" in errors[0] and "1" in errors[0]
 
@@ -72,7 +84,7 @@ def test_log_invalid_tag(monkeypatch: pytest.MonkeyPatch, caplog: LogCaptureFixt
     monkeypatch.chdir(test_project_dir)
     files = FileUtils(["InvalidTag.java"], working_directory="files").get_matching_files()
     with caplog.at_level(logging.ERROR, logger='codestripper'):
-        strip_files(files, "files", "//", "out", True)
+        strip_files(files, "files", output="out")
         errors = [rec.message for rec in caplog.records]
         assert len(errors) == 1 and "InvalidTag.java" in errors[0] and "2" in errors[0]
 
@@ -80,9 +92,9 @@ def test_log_invalid_tag(monkeypatch: pytest.MonkeyPatch, caplog: LogCaptureFixt
 def test_project_out_removes(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.chdir(test_project_dir)
     files = FileUtils(["**/*.java", "pom.xml"], working_directory="testproject").get_matching_files()
-    strip_files(files, "testproject", "//", "out", False)
+    strip_files(files, "testproject", output="out")
     files = FileUtils(["pom.xml"], working_directory="testproject").get_matching_files()
-    strip_files(files, "testproject", "//", "out", False)
+    strip_files(files, "testproject", output="out")
     assert not os.path.isdir(Path("out/src"))
 
 
@@ -92,7 +104,7 @@ def test_fail_on_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptur
 
     with caplog.at_level(logging.ERROR, logger='codestripper'):
         with pytest.raises(Exception):
-            strip_files(files, "files", "//", "out", False, fail_on_error=True)
+            strip_files(files, "files", output="out", fail_on_error=True)
             errors = [rec.message for rec in caplog.records]
             assert len(errors) == 4
 
@@ -102,6 +114,6 @@ def test_non_fail_on_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCa
     files = FileUtils(["**/*.java"], working_directory="files").get_matching_files()
 
     with caplog.at_level(logging.ERROR, logger='codestripper'):
-        strip_files(files, "files", "//", "out", False, fail_on_error=False)
+        strip_files(files, "files", output="out", fail_on_error=False)
         errors = [rec.message for rec in caplog.records]
         assert len(errors) == 4

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ test_project_dir = os.path.join(Path(__file__).parent.absolute())
 def test_main(monkeypatch: pytest.MonkeyPatch, caplog: LogCaptureFixture):
     monkeypatch.chdir(test_project_dir)
     shutil.rmtree("out", ignore_errors=True)
-    args = ["filename", "-c", "//", "-x", "*.class", "-vv", "-o", "out", "-w", "testproject", "**/*.java"]
+    args = ["filename", "-c", ".test:!!", "-c", ".cs:#", "-x", "*.class", "-vv", "-o", "out", "-w", "testproject", "**/*.java"]
     with patch.object(sys, 'argv', args):
         with caplog.at_level(logging.INFO, logger='codestripper'):
             main()

--- a/tests/testproject/pom.xml
+++ b/tests/testproject/pom.xml
@@ -13,7 +13,9 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!--cs:remove:start-->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <!--cs:remove:end-->
     </properties>
 </project>

--- a/tests/testproject/test.test
+++ b/tests/testproject/test.test
@@ -1,0 +1,1 @@
+!!cs:add:Custom file extension <-> comment works!


### PR DESCRIPTION
Add support for:

- Comments that have an open and close tag (e.g. `<!-- -->`)  
  - resolves #11 
- Add support for automatically using correct comment style for common file extensions
- Add support for adding custom comments per file extension 
  - fixes #14 
- Export types 
  - fixes #9 